### PR TITLE
Enhance Yahoo API and add market

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "dev": "npm-run-all build start"
   },
   "dependencies": {
+    "basic-ftp": "^4.6.3",
     "got": "^11.8.1"
   }
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,1 +1,3 @@
 export const BASE_URL = 'https://query1.finance.yahoo.com/v8/finance/chart/'
+
+export const NASDAQ_URL = 'ftp.nasdaqtrader.com'

--- a/src/main.js
+++ b/src/main.js
@@ -1,8 +1,4 @@
-import ticker, { getTicker } from './ticker'
-import { nasdaq } from './market'
-
-getTicker('aapl')
-nasdaq()
+import ticker from './ticker'
 
 export default {
   ticker,

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,8 @@
-import ticker from './ticker'
+import ticker, { getTicker } from './ticker'
+import { nasdaq } from './market'
+
+getTicker('aapl')
+nasdaq()
 
 export default {
   ticker,

--- a/src/market.js
+++ b/src/market.js
@@ -3,8 +3,22 @@ import ftp from 'basic-ftp'
 import { NASDAQ_URL } from './constants'
 import DataStream from './utils/DataStream'
 
+function transformRawNasdaqData(data) {
+  return data
+    .join('')
+    .split('\r\n')
+    .filter((stock) => !stock.includes(' test '))
+    .map((stock) => {
+      const [ticker, name] = stock.split('|')
+      return { ticker, name }
+    })
+}
+
 export async function nasdaq() {
+  const nasdaqData = {}
+
   const client = new ftp.Client()
+
   const rawNasdaqListedData = new DataStream()
   const rawNasdaqOtherData = new DataStream()
 
@@ -13,14 +27,34 @@ export async function nasdaq() {
       host: NASDAQ_URL,
     })
 
+    // Get data from Nasdaq FTP
     await client.cd('SymbolDirectory')
     await client.downloadTo(rawNasdaqListedData, 'nasdaqlisted.txt')
     await client.downloadTo(rawNasdaqOtherData, 'otherlisted.txt')
+
+    // Parse both datasets retrieved from Nasdaq FTP
+    const parsedNasdaqListedData = transformRawNasdaqData(
+      rawNasdaqListedData.chunks
+    )
+    const parsedNasdaqOtherData = transformRawNasdaqData(
+      rawNasdaqOtherData.chunks
+    )
+
+    // Merge both datasets, making sure we have no duplicates
+    for (const company of parsedNasdaqListedData) {
+      nasdaqData[company.ticker] = company
+    }
+
+    for (const company of parsedNasdaqOtherData) {
+      nasdaqData[company.ticker] = company
+    }
   } catch (err) {
     console.log(err)
   }
 
   client.close()
+
+  return Object.values(nasdaqData)
 }
 
 export default {

--- a/src/market.js
+++ b/src/market.js
@@ -1,0 +1,28 @@
+import ftp from 'basic-ftp'
+
+import { NASDAQ_URL } from './constants'
+import DataStream from './utils/DataStream'
+
+export async function nasdaq() {
+  const client = new ftp.Client()
+  const rawNasdaqListedData = new DataStream()
+  const rawNasdaqOtherData = new DataStream()
+
+  try {
+    await client.access({
+      host: NASDAQ_URL,
+    })
+
+    await client.cd('SymbolDirectory')
+    await client.downloadTo(rawNasdaqListedData, 'nasdaqlisted.txt')
+    await client.downloadTo(rawNasdaqOtherData, 'otherlisted.txt')
+  } catch (err) {
+    console.log(err)
+  }
+
+  client.close()
+}
+
+export default {
+  nasdaq,
+}

--- a/src/ticker.js
+++ b/src/ticker.js
@@ -1,10 +1,8 @@
-import got from 'got'
-
-import { BASE_URL } from './constants'
+import { getData } from './yfinance'
 
 export async function getTicker(ticker) {
-  const response = await got(`${BASE_URL}/${ticker}`)
-  console.log(response.body)
+  const tickerData = await getData(ticker)
+  return tickerData
 }
 
 export default {

--- a/src/utils/DataStream.js
+++ b/src/utils/DataStream.js
@@ -1,0 +1,13 @@
+import stream from 'stream'
+
+export default class DataStream extends stream.Writable {
+  constructor() {
+    super()
+    this.chunks = []
+  }
+
+  _write(chunk, enc, next) {
+    this.chunks.push(chunk.toString())
+    next()
+  }
+}

--- a/src/yfinance.js
+++ b/src/yfinance.js
@@ -1,0 +1,24 @@
+import got from 'got'
+
+import { BASE_URL } from './constants'
+
+export async function getData(
+  endpoint,
+  params = { startDate: 7223400, interval: '1d' }
+) {
+  const response = await got(`${BASE_URL}/${endpoint}`, {
+    searchParams: {
+      interval: params.interval,
+      period1: new Date(params.startDate).getTime(),
+      period2: params.endDate
+        ? new Date(params.endDate).getTime()
+        : new Date().getTime(),
+    },
+  }).json()
+
+  return response
+}
+
+export default {
+  getData,
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,6 +60,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
+basic-ftp@^4.6.3:
+  version "4.6.3"
+  resolved "https://registry.yarnpkg.com/basic-ftp/-/basic-ftp-4.6.3.tgz#a09dfe0e21fede82f8c2d70ca83f67d0096bf7a1"
+  integrity sha512-u/zMus8UacMmsxko3szgmuMYaf7pvYV/k/rMJb1I9RCByURWaVP7/jii/8cvPWF3Co7qqBgwRMhyI5vg727OhA==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"


### PR DESCRIPTION
This PR:
- [x] Adds the ability to filter Yahoo requests with date periods and intervals
- [x] Adds a `DataStream` for grabbing text files from Nasdaq's FTP
- [x] Adds API for getting the Nasdaq
- [x] Parses Nasdaq data and returns it as JSON